### PR TITLE
fix: Leaderboard users name

### DIFF
--- a/backend/Keyless.API/Controllers/StatisticsGameController.cs
+++ b/backend/Keyless.API/Controllers/StatisticsGameController.cs
@@ -32,11 +32,6 @@ namespace Keyless.API.Controllers
             }
 
             var statistics = await _statisticsGameService.GetByUserIdPagedAsync(id, pagination.PageNumber, pagination.PageSize);
-            if (statistics.Items == null || !statistics.Items.Any())
-            {
-                return NotFound("Statistics not found.");
-            }
-
             return Ok(statistics);
         }
 
@@ -99,7 +94,7 @@ namespace Keyless.API.Controllers
             var aggregate = await _statisticsGameService.GetAggregateByUserIdAsync(id);
             if (aggregate == null || aggregate.GamesCount == 0)
             {
-                return NotFound("Statistics not found.");
+                return Ok(new UserStatsAggregateResponseDTO { UserId = id });
             }
 
             var response = new UserStatsAggregateResponseDTO

--- a/backend/Keyless.API/appsettings.Development.json
+++ b/backend/Keyless.API/appsettings.Development.json
@@ -16,7 +16,7 @@
         }
     },
     "ConnectionStrings": {
-        "DefaultConnection": "Host=localhost;Port=55432;Database=keyless;Username=postgres;Password=postgres"
+        "DefaultConnection": "Host=127.0.0.1;Port=55432;Database=keyless;Username=postgres;Password=postgres"
     },
     "Jwt": {
         "Key": "Keyless.SuperSecretKey.ChangeMe.AtLeast32Chars",

--- a/backend/Keyless.Shared/DTOs/Responses/StatisticsGame/UserStatsAggregateResponseDTO.cs
+++ b/backend/Keyless.Shared/DTOs/Responses/StatisticsGame/UserStatsAggregateResponseDTO.cs
@@ -33,6 +33,6 @@ namespace Keyless.Shared.DTOs.Responses.StatisticsGame
         [Range(0, double.MaxValue)]
         public decimal AverageConsistency { get; set; }
 
-        public DateTime UpdatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
     }
 }

--- a/backend/Keyless.Tests/UnitTests/StatisticsGameControllerTests.cs
+++ b/backend/Keyless.Tests/UnitTests/StatisticsGameControllerTests.cs
@@ -28,25 +28,26 @@ public sealed class StatisticsGameControllerTests
     }
 
     [Fact]
-    public async Task GetStatisticsByUser_WhenNoItemsExist_ReturnsNotFound()
+    public async Task GetStatisticsByUser_WhenNoItemsExist_ReturnsOkWithEmptyResult()
     {
         var userId = Guid.NewGuid();
+        var expected = new PagedResult<StatisticsGameResponseDTO>
+        {
+            Items = [],
+            PageNumber = 1,
+            PageSize = 10,
+            TotalCount = 0
+        };
         var statisticsService = new StubStatisticsGameService
         {
-            PagedByUserResult = new PagedResult<StatisticsGameResponseDTO>
-            {
-                Items = [],
-                PageNumber = 1,
-                PageSize = 10,
-                TotalCount = 0
-            }
+            PagedByUserResult = expected
         };
         var controller = CreateController(statisticsService, userId);
 
         var result = await controller.GetStatisticsByUser(userId, new PaginationRequestDTO { PageNumber = 1, PageSize = 10 });
 
-        result.Should().BeOfType<NotFoundObjectResult>()
-            .Which.Value.Should().Be("Statistics not found.");
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeSameAs(expected);
     }
 
     [Fact]
@@ -221,19 +222,19 @@ public sealed class StatisticsGameControllerTests
     }
 
     [Fact]
-    public async Task GetAverageStatisticsByUser_WhenAggregateDoesNotExist_ReturnsNotFound()
+    public async Task GetAverageStatisticsByUser_WhenAggregateDoesNotExist_ReturnsOkWithEmptyResponse()
     {
         var userId = Guid.NewGuid();
         var controller = CreateController(new StubStatisticsGameService(), userId);
 
         var result = await controller.GetAverageStatisticsByUser(userId);
 
-        result.Should().BeOfType<NotFoundObjectResult>()
-            .Which.Value.Should().Be("Statistics not found.");
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeEquivalentTo(new UserStatsAggregateResponseDTO { UserId = userId });
     }
 
     [Fact]
-    public async Task GetAverageStatisticsByUser_WhenGamesCountIsZero_ReturnsNotFound()
+    public async Task GetAverageStatisticsByUser_WhenGamesCountIsZero_ReturnsOkWithEmptyResponse()
     {
         var userId = Guid.NewGuid();
         var controller = CreateController(new StubStatisticsGameService
@@ -243,8 +244,8 @@ public sealed class StatisticsGameControllerTests
 
         var result = await controller.GetAverageStatisticsByUser(userId);
 
-        result.Should().BeOfType<NotFoundObjectResult>()
-            .Which.Value.Should().Be("Statistics not found.");
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeEquivalentTo(new UserStatsAggregateResponseDTO { UserId = userId });
     }
 
     [Fact]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,7 +9,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+Open [http://localhost:5173](http://localhost:5173) to view it in your browser.
 
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
@@ -22,7 +22,7 @@ See the section about [running tests](https://facebook.github.io/create-react-ap
 ### `npm run e2e`
 
 Runs the initial Playwright end-to-end suite against the local React app and the .NET API.
-The runner starts the frontend on `http://localhost:3000`, starts the API on `http://localhost:5232`, and uses a dedicated SQLite database file named `MonkeyType.E2E.db`.
+The runner starts the frontend on `http://localhost:5173`, starts the API on `http://localhost:5232`, and uses a dedicated SQLite database file named `MonkeyType.E2E.db`.
 
 Before the first run, install the browser dependency with:
 

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -1,6 +1,7 @@
 const { expect } = require("@playwright/test");
 
-const API_BASE_URL = process.env.PLAYWRIGHT_API_BASE_URL || "http://localhost:5232";
+const API_BASE_URL =
+  process.env.PLAYWRIGHT_API_BASE_URL || "http://localhost:5232";
 const TEST_PASSWORD = "Keyless!123";
 
 function createCredentials() {
@@ -20,25 +21,31 @@ function decodeJwt(token) {
 }
 
 async function registerUser(request, credentials) {
-  const registerResponse = await request.post(`${API_BASE_URL}/api/Authentication/register`, {
-    data: credentials,
-  });
+  const registerResponse = await request.post(
+    `${API_BASE_URL}/api/Authentication/register`,
+    {
+      data: credentials,
+    },
+  );
 
   expect(registerResponse.ok(), await registerResponse.text()).toBeTruthy();
 }
 
 async function enableDeterministicGame(page, overrides = {}) {
-  await page.addInitScript((config) => {
-    window.__KEYLESS_E2E__ = config;
-  }, {
-    words: ["focus", "speed", "rhythm", "flow"],
-    timerTickMs: 20,
-    ...overrides,
-  });
+  await page.addInitScript(
+    (config) => {
+      window.__KEYLESS_E2E__ = config;
+    },
+    {
+      words: ["focus", "speed", "rhythm", "flow"],
+      timerTickMs: 20,
+      ...overrides,
+    },
+  );
 }
 
 async function loginThroughUi(page, baseURL, credentials) {
-  await page.goto(baseURL || "http://localhost:3000");
+  await page.goto(baseURL || "http://localhost:5173");
   await page.getByTestId("login-username").fill(credentials.username);
   await page.getByTestId("login-password").fill(credentials.password);
   await page.getByTestId("login-submit").click();
@@ -57,7 +64,9 @@ async function completeTypingRun(page, duration = 15) {
     }
 
     const activeWord = await page.evaluate(() => {
-      const activeWordElement = document.querySelector('[data-testid="active-word"]');
+      const activeWordElement = document.querySelector(
+        '[data-testid="active-word"]',
+      );
       return activeWordElement?.textContent?.trim() || null;
     });
 
@@ -89,7 +98,7 @@ async function fetchUserStats(request, token) {
       headers: {
         Authorization: `Bearer ${token}`,
       },
-    }
+    },
   );
 
   expect(statsResponse.ok()).toBeTruthy();
@@ -98,11 +107,14 @@ async function fetchUserStats(request, token) {
 
 async function fetchUserProfile(request, token) {
   const payload = decodeJwt(token);
-  const profileResponse = await request.get(`${API_BASE_URL}/api/User/${payload.sub}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
+  const profileResponse = await request.get(
+    `${API_BASE_URL}/api/User/${payload.sub}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     },
-  });
+  );
 
   expect(profileResponse.ok()).toBeTruthy();
   return profileResponse.json();

--- a/frontend/e2e/leaderboard-and-auth.spec.js
+++ b/frontend/e2e/leaderboard-and-auth.spec.js
@@ -8,7 +8,11 @@ const {
   getToken,
 } = require("./helpers");
 
-test("saved run appears in leaderboard for the logged in user", async ({ page, request, baseURL }) => {
+test("saved run appears in leaderboard for the logged in user", async ({
+  page,
+  request,
+  baseURL,
+}) => {
   const credentials = createCredentials();
 
   await registerUser(request, credentials);
@@ -21,17 +25,25 @@ test("saved run appears in leaderboard for the logged in user", async ({ page, r
   await page.getByTestId("leaderboard-duration-15").click();
   await expect(page.getByTestId("leaderboard-table")).toBeVisible();
   await expect(page.getByTestId("leaderboard-my-row")).toBeVisible();
-  await expect(page.getByTestId("leaderboard-my-username")).toHaveText(credentials.username);
+  await expect(page.getByTestId("leaderboard-my-username")).toHaveText(
+    credentials.username,
+  );
   await expect(page.getByTestId("leaderboard-my-duration")).toHaveText("15s");
 
-  const myWpm = Number(await page.getByTestId("leaderboard-my-wpm").textContent());
+  const myWpm = Number(
+    await page.getByTestId("leaderboard-my-wpm").textContent(),
+  );
   expect(myWpm).toBeGreaterThan(0);
 });
 
-test("logout removes access to protected routes", async ({ page, request, baseURL }) => {
+test("logout removes access to protected routes", async ({
+  page,
+  request,
+  baseURL,
+}) => {
   const credentials = createCredentials();
 
-  await page.goto((baseURL || "http://localhost:3000") + "/history");
+  await page.goto((baseURL || "http://localhost:5173") + "/history");
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByTestId("login-form")).toBeVisible();
 
@@ -46,10 +58,12 @@ test("logout removes access to protected routes", async ({ page, request, baseUR
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByTestId("login-form")).toBeVisible();
 
-  const tokenAfterLogout = await page.evaluate(() => window.localStorage.getItem("token"));
+  const tokenAfterLogout = await page.evaluate(() =>
+    window.localStorage.getItem("token"),
+  );
   expect(tokenAfterLogout).toBeNull();
 
-  await page.goto((baseURL || "http://localhost:3000") + "/profile");
+  await page.goto((baseURL || "http://localhost:5173") + "/profile");
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByTestId("login-form")).toBeVisible();
 });

--- a/frontend/e2e/register-and-profile.spec.js
+++ b/frontend/e2e/register-and-profile.spec.js
@@ -6,16 +6,23 @@ const {
   fetchUserProfile,
 } = require("./helpers");
 
-test("user can register through the UI and enter the game authenticated", async ({ page, baseURL }) => {
+test("user can register through the UI and enter the game authenticated", async ({
+  page,
+  baseURL,
+}) => {
   const credentials = createCredentials();
 
   await enableDeterministicGame(page);
-  await page.goto((baseURL || "http://localhost:3000") + "/register");
+  await page.goto((baseURL || "http://localhost:5173") + "/register");
   await page.getByTestId("register-username").fill(credentials.username);
   await page.getByTestId("register-email").fill(credentials.email);
-  await page.getByTestId("register-confirm-email").fill(credentials.verifyEmail);
+  await page
+    .getByTestId("register-confirm-email")
+    .fill(credentials.verifyEmail);
   await page.getByTestId("register-password").fill(credentials.password);
-  await page.getByTestId("register-confirm-password").fill(credentials.verifyPassword);
+  await page
+    .getByTestId("register-confirm-password")
+    .fill(credentials.verifyPassword);
   await page.getByTestId("register-submit").click();
 
   await expect(page).toHaveURL(/\/game$/);
@@ -27,7 +34,11 @@ test("user can register through the UI and enter the game authenticated", async 
   expect(token).toBeTruthy();
 });
 
-test("user can edit profile details and changes persist", async ({ page, request, baseURL }) => {
+test("user can edit profile details and changes persist", async ({
+  page,
+  request,
+  baseURL,
+}) => {
   const credentials = createCredentials();
   const updatedProfile = {
     username: `${credentials.username}_edit`,
@@ -35,12 +46,16 @@ test("user can edit profile details and changes persist", async ({ page, request
     biography: "Typing daily with focused E2E coverage.",
   };
 
-  await page.goto((baseURL || "http://localhost:3000") + "/register");
+  await page.goto((baseURL || "http://localhost:5173") + "/register");
   await page.getByTestId("register-username").fill(credentials.username);
   await page.getByTestId("register-email").fill(credentials.email);
-  await page.getByTestId("register-confirm-email").fill(credentials.verifyEmail);
+  await page
+    .getByTestId("register-confirm-email")
+    .fill(credentials.verifyEmail);
   await page.getByTestId("register-password").fill(credentials.password);
-  await page.getByTestId("register-confirm-password").fill(credentials.verifyPassword);
+  await page
+    .getByTestId("register-confirm-password")
+    .fill(credentials.verifyPassword);
   await page.getByTestId("register-submit").click();
   await expect(page).toHaveURL(/\/game$/);
 
@@ -52,26 +67,44 @@ test("user can edit profile details and changes persist", async ({ page, request
 
   await page.getByTestId("profile-edit-username").fill(updatedProfile.username);
   await page.getByTestId("profile-edit-email").fill(updatedProfile.email);
-  await page.getByTestId("profile-edit-biography").fill(updatedProfile.biography);
+  await page
+    .getByTestId("profile-edit-biography")
+    .fill(updatedProfile.biography);
   await page.getByTestId("profile-save-button").click();
 
-  await expect(page.getByTestId("profile-success")).toHaveText("Profile updated successfully");
-  await expect(page.getByTestId("profile-username-value")).toHaveText(updatedProfile.username);
-  await expect(page.getByTestId("profile-email-value")).toHaveText(updatedProfile.email);
-  await expect(page.getByTestId("profile-biography-value")).toContainText(updatedProfile.biography);
-  await expect(page.getByTestId("nav-profile")).toContainText(updatedProfile.username);
+  await expect(page.getByTestId("profile-success")).toHaveText(
+    "Profile updated successfully",
+  );
+  await expect(page.getByTestId("profile-username-value")).toHaveText(
+    updatedProfile.username,
+  );
+  await expect(page.getByTestId("profile-email-value")).toHaveText(
+    updatedProfile.email,
+  );
+  await expect(page.getByTestId("profile-biography-value")).toContainText(
+    updatedProfile.biography,
+  );
+  await expect(page.getByTestId("nav-profile")).toContainText(
+    updatedProfile.username,
+  );
 
   await page.getByTestId("nav-game").click();
   await expect(page).toHaveURL(/\/game$/);
-  await expect(page.getByTestId("nav-profile")).toContainText(updatedProfile.username);
+  await expect(page.getByTestId("nav-profile")).toContainText(
+    updatedProfile.username,
+  );
 
   await page.getByTestId("nav-profile").click();
   await expect(page).toHaveURL(/\/profile$/);
 
   await page.reload();
   await expect(page).toHaveURL(/\/profile$/);
-  await expect(page.getByTestId("nav-profile")).toContainText(updatedProfile.username);
-  await expect(page.getByTestId("profile-username-value")).toHaveText(updatedProfile.username);
+  await expect(page.getByTestId("nav-profile")).toContainText(
+    updatedProfile.username,
+  );
+  await expect(page.getByTestId("profile-username-value")).toHaveText(
+    updatedProfile.username,
+  );
 
   const token = await getToken(page);
   const persistedProfile = await fetchUserProfile(request, token);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "frontend",
             "version": "0.1.0",
+            "hasInstallScript": true,
             "dependencies": {
                 "react": "^19.2.4",
                 "react-dom": "^19.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,6 @@
         "start": "vite",
         "build": "vite build",
         "preview": "vite preview",
-        "postinstall": "playwright install chromium",
         "e2e": "playwright test",
         "e2e:headed": "playwright test --headed",
         "e2e:install": "playwright install chromium",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
         "start": "vite",
         "build": "vite build",
         "preview": "vite preview",
+        "postinstall": "playwright install chromium",
         "e2e": "playwright test",
         "e2e:headed": "playwright test --headed",
         "e2e:install": "playwright install chromium",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -13,7 +13,7 @@ module.exports = defineConfig({
     ["html", { open: "never", outputFolder: "playwright-report" }],
   ],
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:5173",
     trace: "retain-on-failure",
     video: "retain-on-failure",
     screenshot: "only-on-failure",
@@ -27,7 +27,7 @@ module.exports = defineConfig({
     },
     {
       command: "npm start",
-      url: "http://localhost:3000",
+      url: "http://localhost:5173",
       reuseExistingServer: !process.env.CI,
       timeout: 120000,
       env: {

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -132,7 +132,7 @@ export default function Leaderboard() {
                 >
                   {item.userId === myUserId
                     ? myUsername || "you"
-                    : `player ${index + 1}`}
+                    : item.username || `player ${index + 1}`}
                 </td>
                 <td
                   className="wpm-cell"

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,7 +4,7 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3000,
+    port: 5173,
     proxy: {
       "/api": {
         target: "http://localhost:5232",

--- a/render.yaml
+++ b/render.yaml
@@ -16,6 +16,8 @@ services:
       buildCommand: npm ci && npm run build
       staticPublishPath: dist
       autoDeployTrigger: commit
+
+      routes:
           - type: rewrite
             source: /*
             destination: /index.html

--- a/render.yaml
+++ b/render.yaml
@@ -15,9 +15,7 @@ services:
       rootDir: frontend
       buildCommand: npm ci && npm run build
       staticPublishPath: dist
-      autoDeployTrigger: off
-
-      routes:
+      autoDeployTrigger: commit
           - type: rewrite
             source: /*
             destination: /index.html
@@ -41,7 +39,7 @@ services:
       dockerfilePath: Dockerfile
       dockerContext: .
       healthCheckPath: /health
-      autoDeployTrigger: off
+      autoDeployTrigger: commit
 
       envVars:
           - key: ConnectionStrings__DefaultConnection


### PR DESCRIPTION
This pull request introduces several improvements and updates across both the backend and frontend, focusing on API response consistency, test coverage, and frontend environment configuration. The most significant changes include standardizing API responses for empty statistics, updating related unit tests, and aligning frontend development and testing ports and URLs.

**Backend API and Test Improvements:**

* Standardized API responses for empty statistics:
  - [`StatisticsGameController.cs`](diffhunk://#diff-e8840757f4ad720843f62afdea25eb486c4c858e23eef4861ca3d2cd41c37224L35-L39): Changed endpoints to return `Ok` with empty results instead of `NotFound` when no statistics exist for a user. This affects both paged and aggregate statistics endpoints. [[1]](diffhunk://#diff-e8840757f4ad720843f62afdea25eb486c4c858e23eef4861ca3d2cd41c37224L35-L39) [[2]](diffhunk://#diff-e8840757f4ad720843f62afdea25eb486c4c858e23eef4861ca3d2cd41c37224L102-R97)
* Updated unit tests to match new API behavior:
  - [`StatisticsGameControllerTests.cs`](diffhunk://#diff-df0aae78a6f165c381a8f32001d3f4e585924aab4f683d2274e2f64211230c9cL31-R50): Adjusted tests to expect `Ok` responses with empty data instead of `NotFound` when no statistics or aggregate data exist. [[1]](diffhunk://#diff-df0aae78a6f165c381a8f32001d3f4e585924aab4f683d2274e2f64211230c9cL31-R50) [[2]](diffhunk://#diff-df0aae78a6f165c381a8f32001d3f4e585924aab4f683d2274e2f64211230c9cL224-R237) [[3]](diffhunk://#diff-df0aae78a6f165c381a8f32001d3f4e585924aab4f683d2274e2f64211230c9cL246-R248)

**Frontend Environment and E2E Test Updates:**

* Changed default frontend development and test ports:
  - Updated documentation, configuration, and test scripts to use port `5173` instead of `3000` for local development and Playwright E2E tests. [[1]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543L12-R12) [[2]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543L25-R25) [[3]](diffhunk://#diff-de43beabbf492f78ffbc737997bf9586be6d34ea0d56c18fbb32e9e54d98907dL16-R16) [[4]](diffhunk://#diff-de43beabbf492f78ffbc737997bf9586be6d34ea0d56c18fbb32e9e54d98907dL30-R30) [[5]](diffhunk://#diff-3ab42a14055f455cac92d192b5dfc9b850cd36f1ea3410d1694a602f6d4b83c1L7-R7)
* Improved Playwright E2E test reliability and code style:
  - Refactored E2E helper and spec files for better readability and consistency with new URLs and ports. [[1]](diffhunk://#diff-30e39725033b5e79b2be3761597d30c5825370cc73a69a6472f9262529240304L23-R48) [[2]](diffhunk://#diff-30e39725033b5e79b2be3761597d30c5825370cc73a69a6472f9262529240304L60-R69) [[3]](diffhunk://#diff-30e39725033b5e79b2be3761597d30c5825370cc73a69a6472f9262529240304L92-R101) [[4]](diffhunk://#diff-30e39725033b5e79b2be3761597d30c5825370cc73a69a6472f9262529240304L101-R117) [[5]](diffhunk://#diff-15c35c9b3645a7ddee003e7b6ce12f89465add38cbd13b5362e090f681aeb20aL11-R15) [[6]](diffhunk://#diff-15c35c9b3645a7ddee003e7b6ce12f89465add38cbd13b5362e090f681aeb20aL24-R46) [[7]](diffhunk://#diff-15c35c9b3645a7ddee003e7b6ce12f89465add38cbd13b5362e090f681aeb20aL49-R66) [[8]](diffhunk://#diff-60974fb1f28f080380d1de4b771f98e3a0bf9555908e772997a3284aff5a6d91L9-R25) [[9]](diffhunk://#diff-60974fb1f28f080380d1de4b771f98e3a0bf9555908e772997a3284aff5a6d91L30-R58) [[10]](diffhunk://#diff-60974fb1f28f080380d1de4b771f98e3a0bf9555908e772997a3284aff5a6d91L55-R107)

**Other Notable Changes:**

* Added Playwright install step to frontend `postinstall` script for smoother local setup. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R28) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR10)
* Updated leaderboard display to show usernames if available.
* Changed backend development DB host from `localhost` to `127.0.0.1` for consistency.